### PR TITLE
Update FindOpenMesh.cmake

### DIFF
--- a/cmake/FindOpenMesh.cmake
+++ b/cmake/FindOpenMesh.cmake
@@ -5,56 +5,152 @@
 # OPENMESH_FOUND           - system has OPENMESH
 # OPENMESH_INCLUDE_DIRS    - the OPENMESH include directories
 # OPENMESH_LIBRARIES       - Link these to use OPENMESH
+# OPENMESH_LIBRARY_DIR     - directory where the libraries are included
 #
-# Copyright 2013 Computer Graphics Group, RWTH Aachen University
+# Copyright 2015 Computer Graphics Group, RWTH Aachen University
 # Authors: Jan Möbius <moebius@cs.rwth-aachen.de>
 #          Hans-Christian Ebke <ebke@cs.rwth-aachen.de>
 #
-# This file is part of QEx.
-# 
-# QEx is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by the Free
-# Software Foundation, either version 3 of the License, or (at your
-# option) any later version.
-# 
-# QEx is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
-# for more details.
-# 
-# You should have received a copy of the GNU General Public License
-# along with QEx.  If not, see <http://www.gnu.org/licenses/>.
-#   
+#
+#===========================================================================
+#                                                                           
+#                               OpenMesh                                    
+#           Copyright (c) 2001-2015, RWTH-Aachen University                 
+#           Department of Computer Graphics and Multimedia                 
+#                          All rights reserved.                             
+#                            www.openmesh.org                               
+#                                                                           
+#---------------------------------------------------------------------------
+# This file is part of OpenMesh.                                            
+#---------------------------------------------------------------------------
+#                                                                           
+# Redistribution and use in source and binary forms, with or without        
+# modification, are permitted provided that the following conditions        
+# are met:                                                                  
+#                                                                           
+# 1. Redistributions of source code must retain the above copyright notice, 
+#    this list of conditions and the following disclaimer.                  
+#                                                                           
+# 2. Redistributions in binary form must reproduce the above copyright      
+#    notice, this list of conditions and the following disclaimer in the    
+#    documentation and/or other materials provided with the distribution.   
+#                                                                           
+# 3. Neither the name of the copyright holder nor the names of its          
+#    contributors may be used to endorse or promote products derived from   
+#    this software without specific prior written permission.               
+#                                                                           
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS       
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A           
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER 
+# OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,  
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,       
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR        
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING      
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS        
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.              
+#                                                                            
+#===========================================================================
 
-IF (OPENMESH_INCLUDE_DIR)
-  # Already in cache, be silent
-  SET(OPENMESH_FIND_QUIETLY TRUE)
-ENDIF (OPENMESH_INCLUDE_DIR)
+cmake_minimum_required(VERSION 2.8.9)
 
-FIND_PATH(OPENMESH_INCLUDE_DIR OpenMesh/Core/Mesh/PolyMeshT.hh
-	  PATHS /usr/local/include 
-                /usr/include 
-                /usr/local/OpenMesh-2.0rc4/include
-                "${CMAKE_SOURCE_DIR}/OpenMesh/src"
-                "${CMAKE_SOURCE_DIR}/libs_required/OpenMesh/src"
-                "${CMAKE_SOURCE_DIR}/../OpenMesh/src"
-                /ACG/acgdev/gcc-4.0-x86_64/OM2/OpenMesh-2.0/installed/include
-		    "C:\\Program Files\\OpenMesh 2.0\\include"
-                )
-SET(OPENMESH_LIBRARY_DIR NOTFOUND CACHE PATH "The directory where the OpenMesh libraries can be found.")
-SET(SEARCH_PATHS
-    "${OPENMESH_INCLUDE_DIR}/../lib"
-    "${OPENMESH_INCLUDE_DIR}/../lib/OpenMesh"
-    "${OPENMESH_LIBRARY_DIR}")
-FIND_LIBRARY(OPENMESH_CORE_LIBRARY NAMES OpenMeshCored OpenMeshCore PATHS ${SEARCH_PATHS})
-FIND_LIBRARY(OPENMESH_TOOLS_LIBRARY NAMES OpenMeshToolsd OpenMeshTools PATHS ${SEARCH_PATHS})
+#if already found via finder or simulated finder in openmesh CMakeLists.txt, skip the search
+IF (NOT OPENMESH_FOUND) 
+  SET (SEARCH_PATHS 
+    /usr/local/
+    /usr/
+    "${CMAKE_SOURCE_DIR}/OpenMesh/src/OpenMesh"
+    "${CMAKE_SOURCE_DIR}/libs_required/OpenMesh/src/OpenMesh"
+    "${CMAKE_SOURCE_DIR}/../OpenMesh/src/OpenMesh"
+    "C:/Program Files/OpenMesh 8.1"
+    "C:/Program Files/OpenMesh 8.0"
+    "C:/Program Files/OpenMesh 7.2"
+    "C:/Program Files/OpenMesh 7.1"
+    "C:/Program Files/OpenMesh 7.0"
+    "C:/Program Files/OpenMesh 6.3"
+    "C:/Program Files/OpenMesh 6.2"
+    "C:/Program Files/OpenMesh 6.1"
+    "C:/Program Files/OpenMesh 6.0"
+    "C:/Program Files/OpenMesh 5.2"
+    "C:/Program Files/OpenMesh 5.1"
+    "C:/Program Files/OpenMesh 5.0"
+    "C:/Program Files/OpenMesh 4.2"
+    "C:/Program Files/OpenMesh 4.1"
+    "C:/Program Files/OpenMesh 4.0"
+    "C:/Program Files/OpenMesh 3.4"
+    "C:/Program Files/OpenMesh 3.3"
+    "C:/Program Files/OpenMesh 3.2"
+    "C:/Program Files/OpenMesh 3.1"
+    "C:/Program Files/OpenMesh 3.0"
+    "C:/Program Files/OpenMesh 2.4.1"
+    "C:/Program Files/OpenMesh 2.4"
+    "C:/Program Files/OpenMesh 2.0/include"
+    "C:/libs/OpenMesh 8.1"
+    "C:/libs/OpenMesh 8.0"
+    "C:/libs/OpenMesh 7.1"
+    "C:/libs/OpenMesh 7.0"
+    "C:/libs/OpenMesh 6.3"
+    "C:/libs/OpenMesh 6.2"
+    "C:/libs/OpenMesh 6.1"
+    "C:/libs/OpenMesh 6.0"
+    "C:/libs/OpenMesh 5.2"
+    "C:/libs/OpenMesh 5.1"
+    "C:/libs/OpenMesh 5.0"
+    "C:/libs/OpenMesh 4.2"
+    "C:/libs/OpenMesh 4.1"
+    "C:/libs/OpenMesh 4.0"
+    "C:/libs/OpenMesh 3.4"
+    "C:/libs/OpenMesh 3.3"
+    "C:/libs/OpenMesh 3.2"
+    "C:/libs/OpenMesh 3.1"
+    "C:/libs/OpenMesh 3.0"
+    "C:/libs/OpenMesh 2.4.1"
+    "C:/libs/OpenMesh 2.4"
+    "${OPENMESH_LIBRARY_DIR}"
+  )
 
-INCLUDE (FindPackageHandleStandardArgs)
+  FIND_PATH (OPENMESH_INCLUDE_DIR OpenMesh/Core/Mesh/PolyMeshT.hh
+    PATHS ${SEARCH_PATHS}
+    PATH_SUFFIXES include)
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(OpenMesh DEFAULT_MSG OPENMESH_CORE_LIBRARY OPENMESH_TOOLS_LIBRARY OPENMESH_INCLUDE_DIR)
+  FIND_LIBRARY(OPENMESH_CORE_LIBRARY_RELEASE NAMES OpenMeshCore
+    PATHS ${SEARCH_PATHS}
+    PATH_SUFFIXES lib lib64)
 
-IF (OPENMESH_FOUND)
-   SET(OPENMESH_LIBRARIES "${OPENMESH_CORE_LIBRARY}" "${OPENMESH_TOOLS_LIBRARY}")
-   SET(OPENMESH_INCLUDE_DIRS "${OPENMESH_INCLUDE_DIR}")
-ENDIF (OPENMESH_FOUND)
+  FIND_LIBRARY(OPENMESH_CORE_LIBRARY_DEBUG NAMES OpenMeshCored 
+    PATHS ${SEARCH_PATHS}
+    PATH_SUFFIXES lib lib64)
 
+  FIND_LIBRARY(OPENMESH_TOOLS_LIBRARY_RELEASE NAMES OpenMeshTools
+    PATHS ${SEARCH_PATHS}
+    PATH_SUFFIXES lib lib64)
+
+  FIND_LIBRARY(OPENMESH_TOOLS_LIBRARY_DEBUG NAMES OpenMeshToolsd
+    PATHS ${SEARCH_PATHS}
+    PATH_SUFFIXES lib lib64)
+
+#select configuration depending on platform (optimized... on windows)
+  include(SelectLibraryConfigurations)
+  select_library_configurations( OPENMESH_TOOLS )
+  select_library_configurations( OPENMESH_CORE )
+
+  set(OPENMESH_LIBRARIES ${OPENMESH_CORE_LIBRARY} ${OPENMESH_TOOLS_LIBRARY} )
+  set(OPENMESH_INCLUDE_DIRS ${OPENMESH_INCLUDE_DIR} )
+
+#checks, if OPENMESH was found and sets OPENMESH_FOUND if so
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(OpenMesh  DEFAULT_MSG
+                                    OPENMESH_CORE_LIBRARY OPENMESH_TOOLS_LIBRARY OPENMESH_INCLUDE_DIR)
+ 
+#sets the library dir 
+  if ( OPENMESH_CORE_LIBRARY_RELEASE )
+    get_filename_component(_OPENMESH_LIBRARY_DIR ${OPENMESH_CORE_LIBRARY_RELEASE} PATH)
+  else( OPENMESH_CORE_LIBRARY_RELEASE )
+    get_filename_component(_OPENMESH_LIBRARY_DIR ${OPENMESH_CORE_LIBRARY_DEBUG} PATH)
+  endif( OPENMESH_CORE_LIBRARY_RELEASE )
+  set (OPENMESH_LIBRARY_DIR "${_OPENMESH_LIBRARY_DIR}" CACHE PATH "The directory where the OpenMesh libraries can be found.")
+  
+ 
+  mark_as_advanced(OPENMESH_INCLUDE_DIR OPENMESH_CORE_LIBRARY_RELEASE OPENMESH_CORE_LIBRARY_DEBUG OPENMESH_TOOLS_LIBRARY_RELEASE OPENMESH_TOOLS_LIBRARY_DEBUG OPENMESH_LIBRARY_DIR)
+endif()


### PR DESCRIPTION
Replace FindOpenMesh.cmake with the current version from OpenMesh 8.1. This makes release mode compilations on Windows possible again.